### PR TITLE
[Fix #56] Add ASF licence header to all source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 ![Gremlint Github Header 1920x1024](https://user-images.githubusercontent.com/25663729/88488788-d5a73700-cf8f-11ea-9adb-03d62c77c1b7.png)
 
 ### What is Gremlint?

--- a/build/build.js
+++ b/build/build.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { readContentFromFile, writeContentToFile } = require('./fileUtils');
 const { extractImportPaths } = require('./parseUtils');
 const { getOrderedListOfFiles } = require('./sortUtils');

--- a/build/fileUtils.js
+++ b/build/fileUtils.js
@@ -1,6 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const fs = require('fs');
 
-const readContentFromFile = filePath =>
+const readContentFromFile = (filePath) =>
   fs.readFileSync(`./${filePath}`, 'utf8');
 
 const writeContentToFile = (content, filename) => {

--- a/build/index.js
+++ b/build/index.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { build } = require('./build');
 
 build();

--- a/build/parseUtils.js
+++ b/build/parseUtils.js
@@ -1,4 +1,23 @@
-const trim = string => {
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const trim = (string) => {
   const withoutSpaces = string.trim();
   const withoutStartQuote = [`'`, '"', '`'].includes(withoutSpaces.charAt(0))
     ? withoutSpaces.slice(1)
@@ -11,7 +30,7 @@ const trim = string => {
   return withoutEndQuote;
 };
 
-const extractImportPaths = fileContent => {
+const extractImportPaths = (fileContent) => {
   let remainingFile = fileContent;
   const paths = [];
   while (remainingFile.includes('include(')) {

--- a/build/sortUtils.js
+++ b/build/sortUtils.js
@@ -1,7 +1,26 @@
 /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
  * @param {{ content: string; dependencies: string[] }} importedFilePaths
  */
-const getOrderedListOfFiles = importedFilePaths => {
+const getOrderedListOfFiles = (importedFilePaths) => {
   const orderedListOfFiles = [];
   const handledPaths = [];
   let remainingFiles = Object.entries(importedFilePaths).map(
@@ -25,7 +44,7 @@ const getOrderedListOfFiles = importedFilePaths => {
     );
     remainingFiles.forEach(({ path, dependencies }, index) => {
       remainingFiles[index].dependencies = dependencies.filter(
-        dependency => dependency !== firstFileWithoutDependencies.path
+        (dependency) => dependency !== firstFileWithoutDependencies.path
       );
     });
   }

--- a/dist/index.html
+++ b/dist/index.html
@@ -9,7 +9,26 @@ const include = path => modules[path];
 
 modules['src/libs/observable/Observable.js'] = (() => {
   const module = { exports: {} };
-  class Observable {
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class Observable {
   constructor(value) {
     // Maybe this can cause an id collision of two observables created almost at the same time
     this._id = `${Math.random()}${+new Date()}`;
@@ -43,7 +62,26 @@ module.exports = Observable;
 
 modules['src/libs/simpleHTML/SimpleHTML.js'] = (() => {
   const module = { exports: {} };
-  const flatten = (items) => {
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const flatten = (items) => {
   const flat = [];
 
   items.forEach((item) => {
@@ -258,7 +296,26 @@ module.exports = {
 
 modules['src/components/fadeIn/FadeIn.js'] = (() => {
   const module = { exports: {} };
-  const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 
 const FadeIn = (getProps, children) => {
   let opacity = 0;
@@ -287,7 +344,26 @@ module.exports = FadeIn;
 
 modules['src/libs/simpleRouter/SimpleRouter.js'] = (() => {
   const module = { exports: {} };
-  function SimpleRouter(routes) {
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+function SimpleRouter(routes) {
   /**
    * @param {string} routes
    */
@@ -485,7 +561,26 @@ module.exports = SimpleRouter;
 
 modules['src/router/Router.js'] = (() => {
   const module = { exports: {} };
-  const SimpleRouter = include('src/libs/simpleRouter/SimpleRouter.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const SimpleRouter = include('src/libs/simpleRouter/SimpleRouter.js');
 
 const router = new SimpleRouter({
   '/': 'Gremlint - Query formatter',
@@ -507,7 +602,26 @@ module.exports = {
 
 modules['src/libs/simpleColorPalette/SimpleColorPalette.js'] = (() => {
   const module = { exports: {} };
-  const BorderColor = 'lightgray';
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const BorderColor = 'lightgray';
 const TextColor = 'slategray';
 const InputTextColor = 'darkslategray';
 const HighlightedTextColor = 'darkslategray';
@@ -530,7 +644,26 @@ module.exports = {
 
 modules['src/components/loadingAnimation/LoadingAnimation.js'] = (() => {
   const module = { exports: {} };
-  const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 const { White } = include('src/libs/simpleColorPalette/SimpleColorPalette.js');
 
 const LoadingAnimation = (getProps) => {
@@ -654,7 +787,26 @@ module.exports = LoadingAnimation;
 
 modules['src/views/styleGuide/rules/Rules.js'] = (() => {
   const module = { exports: {} };
-  const rules = [
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const rules = [
   {
     title: 'Break long queries into multiple lines',
     explanation: `What is considered too long depends on your application.
@@ -981,7 +1133,26 @@ module.exports = { rules };
 
 modules['src/components/queryInput/QueryInput.js'] = (() => {
   const module = { exports: {} };
-  const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 const { InputTextColor } = include(
   'src/libs/simpleColorPalette/SimpleColorPalette.js'
 );
@@ -1026,7 +1197,26 @@ module.exports = QueryInput;
 
 modules['src/components/code/Code.js'] = (() => {
   const module = { exports: {} };
-  const { html, If } = include('src/libs/simpleHTML/SimpleHTML.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { html, If } = include('src/libs/simpleHTML/SimpleHTML.js');
 const { DisabledTextColor, TextColor } = include(
   'src/libs/simpleColorPalette/SimpleColorPalette.js'
 );
@@ -1088,7 +1278,26 @@ module.exports = Code;
 
 modules['src/libs/simpleFP/SimpleFP.js'] = (() => {
   const module = { exports: {} };
-  const last = (array) => array.slice(-1)[0];
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const last = (array) => array.slice(-1)[0];
 
 const pipe = (...fns) => (value) => fns.reduce((value, fn) => fn(value), value);
 
@@ -1099,7 +1308,26 @@ module.exports = { last, pipe };
 
 modules['src/libs/gremlint/parseToSyntaxTree/ParseToSyntaxTree.js'] = (() => {
   const module = { exports: {} };
-  const { last, pipe } = include('src/libs/simpleFP/SimpleFP.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { last, pipe } = include('src/libs/simpleFP/SimpleFP.js');
 
 const tokenizeOnTopLevelPunctuation = (query) => {
   word = '';
@@ -1356,13 +1584,30 @@ module.exports = {
 
 modules['src/libs/simpleStyle/SimpleStyle.js'] = (() => {
   const module = { exports: {} };
-  const {
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const {
   TextColor,
   InputTextColor,
   HighlightedTextColor,
-  DisabledTextColor,
   HighlightColor,
-  White,
 } = include('src/libs/simpleColorPalette/SimpleColorPalette.js');
 
 // A unit is 20px
@@ -1433,7 +1678,26 @@ module.exports = {
 
 modules['src/components/navigationButton/NavigationButton.js'] = (() => {
   const module = { exports: {} };
-  const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 const { getInlineContainerStyle, getLinkStyle } = include(
   'src/libs/simpleStyle/SimpleStyle.js'
 );
@@ -1478,7 +1742,26 @@ module.exports = NavigationButton;
 
 modules['src/components/navigator/Navigator.js'] = (() => {
   const module = { exports: {} };
-  const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 const { White } = include('src/libs/simpleColorPalette/SimpleColorPalette.js');
 const NavigationButton = include(
   'src/components/navigationButton/NavigationButton.js'
@@ -1536,7 +1819,26 @@ module.exports = Navigator;
 
 modules['src/components/textButton/TextButton.js'] = (() => {
   const module = { exports: {} };
-  const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 const { getTextButtonStyle } = include('src/libs/simpleStyle/SimpleStyle.js');
 
 const TextButton = (getProps) => {
@@ -1582,7 +1884,26 @@ module.exports = TextButton;
 
 modules['src/components/title/Title.js'] = (() => {
   const module = { exports: {} };
-  const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 const { TextColor } = include(
   'src/libs/simpleColorPalette/SimpleColorPalette.js'
 );
@@ -1613,7 +1934,26 @@ module.exports = Title;
 
 modules['src/components/paragraph/Paragraph.js'] = (() => {
   const module = { exports: {} };
-  const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 const { TextColor } = include(
   'src/libs/simpleColorPalette/SimpleColorPalette.js'
 );
@@ -1644,7 +1984,26 @@ module.exports = Paragraph;
 
 modules['src/components/spacer/Spacer.js'] = (() => {
   const module = { exports: {} };
-  const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 
 const Spacer = () => html('div', { style: 'height: 20px' }, []);
 
@@ -1655,7 +2014,26 @@ module.exports = Spacer;
 
 modules['src/components/styleGuideRule/StyleGuideRule.js'] = (() => {
   const module = { exports: {} };
-  const Title = include('src/components/title/Title.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const Title = include('src/components/title/Title.js');
 const Paragraph = include('src/components/paragraph/Paragraph.js');
 const Code = include('src/components/code/Code.js');
 const Spacer = include('src/components/spacer/Spacer.js');
@@ -1681,7 +2059,26 @@ module.exports = StyleGuideRule;
 
 modules['src/views/styleGuide/StyleGuide.js'] = (() => {
   const module = { exports: {} };
-  const StyleGuideRule = include(
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const StyleGuideRule = include(
   'src/components/styleGuideRule/StyleGuideRule.js'
 );
 const { html, Each } = include('src/libs/simpleHTML/SimpleHTML.js');
@@ -1708,7 +2105,26 @@ module.exports = StyleGuide;
 
 modules['src/libs/gremlint/formatSyntaxTree/formatString/FormatString.js'] = (() => {
   const module = { exports: {} };
-  const formatString = (config) => (syntaxTree) => {
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const formatString = (config) => (syntaxTree) => {
   return {
     type: 'string',
     string: syntaxTree.string,
@@ -1723,7 +2139,26 @@ module.exports = { formatString };
 
 modules['src/libs/gremlint/formatSyntaxTree/formatWord/FormatWord.js'] = (() => {
   const module = { exports: {} };
-  const formatWord = (config) => (syntaxTree) => {
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const formatWord = (config) => (syntaxTree) => {
   return {
     type: 'word',
     word: syntaxTree.word,
@@ -1740,7 +2175,26 @@ module.exports = { formatWord };
 
 modules['src/libs/gremlint/utils.js'] = (() => {
   const module = { exports: {} };
-  const spaces = (numberOfSpaces) => Array(numberOfSpaces + 1).join(' ');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const spaces = (numberOfSpaces) => Array(numberOfSpaces + 1).join(' ');
 
 module.exports = {
   spaces,
@@ -1751,7 +2205,26 @@ module.exports = {
 
 modules['src/libs/gremlint/recreateQueryStringFromFormattedSyntaxTree/RecreateQueryStringFromFormattedSyntaxTree.js'] = (() => {
   const module = { exports: {} };
-  const { spaces } = include('src/libs/gremlint/utils.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { spaces } = include('src/libs/gremlint/utils.js');
 
 const recreateQueryStringFromFormattedSyntaxTree = (syntaxTree) => {
   if (syntaxTree.type === 'traversal') {
@@ -1800,7 +2273,26 @@ module.exports = {
 
 modules['src/components/toggle/styles.js'] = (() => {
   const module = { exports: {} };
-  const { BorderColor, HighlightedTextColor, TextColor, White } = include(
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { BorderColor, HighlightedTextColor, TextColor, White } = include(
   'src/libs/simpleColorPalette/SimpleColorPalette.js'
 );
 
@@ -1858,7 +2350,26 @@ module.exports = {
 
 modules['src/components/toggle/Toggle.js'] = (() => {
   const module = { exports: {} };
-  const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 const {
   getToggleContainerStyle,
   getOptionStyle,
@@ -1917,7 +2428,26 @@ module.exports = Toggle;
 
 modules['src/libs/gremlint/recreateQueryOnelinerFromSyntaxTree/RecreateQueryOnelinerFromSyntaxTree.js'] = (() => {
   const module = { exports: {} };
-  const { spaces } = include('src/libs/gremlint/utils.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { spaces } = include('src/libs/gremlint/utils.js');
 
 const recreateQueryOnelinerFromSyntaxTree = (indentation = 0) => (
   syntaxTree
@@ -1954,7 +2484,26 @@ module.exports = {
 
 modules['src/libs/gremlint/formatSyntaxTree/utils.js'] = (() => {
   const module = { exports: {} };
-  const withIndentation = (indentation) => (config) => ({
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const withIndentation = (indentation) => (config) => ({
   ...config,
   indentation,
 });
@@ -1995,7 +2544,26 @@ module.exports = {
 
 modules['src/libs/gremlint/formatSyntaxTree/formatMethod/FormatMethod.js'] = (() => {
   const module = { exports: {} };
-  const { pipe } = include('src/libs/simpleFP/SimpleFP.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { pipe } = include('src/libs/simpleFP/SimpleFP.js');
 const { recreateQueryOnelinerFromSyntaxTree } = include(
   'src/libs/gremlint/recreateQueryOnelinerFromSyntaxTree/RecreateQueryOnelinerFromSyntaxTree.js'
 );
@@ -2051,7 +2619,26 @@ module.exports = { formatMethod };
 
 modules['src/libs/gremlint/formatSyntaxTree/formatTraversal/getStepGroups/utils.js'] = (() => {
   const module = { exports: {} };
-  const isTraversalSource = (step) => step.type === 'word' && step.word === 'g';
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const isTraversalSource = (step) => step.type === 'word' && step.word === 'g';
 
 const isModulator = (step) =>
   step.type === 'method' &&
@@ -2080,7 +2667,26 @@ module.exports = { isTraversalSource, isModulator };
 
 modules['src/libs/gremlint/formatSyntaxTree/formatTraversal/getStepGroups/GetStepGroups.js'] = (() => {
   const module = { exports: {} };
-  const { pipe } = include('src/libs/simpleFP/SimpleFP.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { pipe } = include('src/libs/simpleFP/SimpleFP.js');
 const { withZeroIndentation, withIncreasedIndentation, withDotInfo } = include(
   'src/libs/gremlint/formatSyntaxTree/utils.js'
 );
@@ -2279,14 +2885,32 @@ module.exports = { getStepGroups };
 
 modules['src/libs/gremlint/formatSyntaxTree/formatTraversal/FormatTraversal.js'] = (() => {
   const module = { exports: {} };
-  const { pipe } = include('src/libs/simpleFP/SimpleFP.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { recreateQueryOnelinerFromSyntaxTree } = include(
   'src/libs/gremlint/recreateQueryOnelinerFromSyntaxTree/RecreateQueryOnelinerFromSyntaxTree.js'
 );
 const { getStepGroups } = include(
   'src/libs/gremlint/formatSyntaxTree/formatTraversal/getStepGroups/GetStepGroups.js'
 );
-const { withDotInfo, withZeroIndentation } = include(
+const { withZeroIndentation } = include(
   'src/libs/gremlint/formatSyntaxTree/utils.js'
 );
 
@@ -2322,7 +2946,26 @@ module.exports = { formatTraversal };
 
 modules['src/libs/gremlint/formatSyntaxTree/FormatSyntaxTree.js'] = (() => {
   const module = { exports: {} };
-  const { formatTraversal } = include(
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { formatTraversal } = include(
   'src/libs/gremlint/formatSyntaxTree/formatTraversal/FormatTraversal.js'
 );
 const { formatMethod } = include(
@@ -2355,7 +2998,26 @@ module.exports = { formatSyntaxTree };
 
 modules['src/libs/gremlint/Gremlint.js'] = (() => {
   const module = { exports: {} };
-  const { pipe } = include('src/libs/simpleFP/SimpleFP.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { pipe } = include('src/libs/simpleFP/SimpleFP.js');
 const { parseToSyntaxTree } = include(
   'src/libs/gremlint/parseToSyntaxTree/ParseToSyntaxTree.js'
 );
@@ -2390,7 +3052,26 @@ module.exports = {
 
 modules['src/store/Store.js'] = (() => {
   const module = { exports: {} };
-  const Observable = include('src/libs/observable/Observable.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const Observable = include('src/libs/observable/Observable.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 
 const atom = (initialValue) => {
@@ -2524,7 +3205,26 @@ module.exports = {
 
 modules['src/views/queryFormatter/advancedOptions/AdvancedOptions.js'] = (() => {
   const module = { exports: {} };
-  const Toggle = include('src/components/toggle/Toggle.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const Toggle = include('src/components/toggle/Toggle.js');
 const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 const {
   getIndentation,
@@ -2594,7 +3294,26 @@ module.exports = AdvancedOptions;
 
 modules['src/views/queryFormatter/QueryFormatter.js'] = (() => {
   const module = { exports: {} };
-  const QueryInput = include('src/components/queryInput/QueryInput.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const QueryInput = include('src/components/queryInput/QueryInput.js');
 const Code = include('src/components/code/Code.js');
 const TextButton = include('src/components/textButton/TextButton.js');
 const AdvancedOptions = include(
@@ -2651,7 +3370,26 @@ module.exports = QueryFormatter;
 
 modules['src/app/App.js'] = (() => {
   const module = { exports: {} };
-  const Navigator = include('src/components/navigator/Navigator.js');
+  /**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const Navigator = include('src/components/navigator/Navigator.js');
 const StyleGuide = include('src/views/styleGuide/StyleGuide.js');
 const QueryFormatter = include('src/views/queryFormatter/QueryFormatter.js');
 const LoadingAnimation = include(
@@ -2707,6 +3445,25 @@ module.exports = App;
 })();
 
 window.addEventListener('load', () => {
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const Observable = include('src/libs/observable/Observable.js');
 const App = include('src/app/App.js');
 const Store = include('src/store/Store.js');

--- a/legacy/index.html
+++ b/legacy/index.html
@@ -1,23 +1,42 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 <!DOCTYPE html>
 
 <style>
   #formatter {
     font-family: Arial;
     max-width: 1200px;
-    color: #2F3D45;
+    color: #2f3d45;
     width: 100%;
   }
   #inputQuery {
     background-color: #f5f5f5;
     border-radius: 10px;
     line-height: normal;
-    border-style:solid;
+    border-style: solid;
     font-size: 18px;
-    color: #2F3D45;
+    color: #2f3d45;
     outline: none;
     padding: 18px;
     resize: none;
-    border:none;
+    border: none;
     width: 100%;
   }
   #outputQuery {
@@ -33,14 +52,13 @@
 </style>
 
 <script>
-  
   // Returns a given number of consecutive non-breaking spaces
-  const spaces = numberOfSpaces => Array(numberOfSpaces+1).join('&nbsp;');
+  const spaces = (numberOfSpaces) => Array(numberOfSpaces + 1).join('&nbsp;');
 
-  const isAlphabetical = character => 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.includes(character);
+  const isAlphabetical = (character) =>
+    'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.includes(character);
 
-  const format = query => {
-
+  const format = (query) => {
     // Store the number of open parenthesis at the time of g.V()
     let gDotV = [];
     let unclosedParenthesisCount = 0;
@@ -48,7 +66,7 @@
     let unclosedString = false;
     let unclosedValue = false;
     let unclosedComment = false;
-    
+
     // Boolean value to check if the character currently parsed belongs to a Gremlin section
     let isGremlin = query.charAt(0) === 'g';
 
@@ -57,11 +75,10 @@
     queryArray = query.split('');
 
     for (let i = 0; i < queryArray.length; i++) {
-      
       /*------------------------------------------------------------------------
       General formatting
       ------------------------------------------------------------------------*/
-      
+
       // Color string content
       if (!unclosedComment && queryArray[i] === "'") {
         unclosedString = !unclosedString;
@@ -76,7 +93,7 @@
 
       // Add space after commas if the comma is not within a string
       queryArray[i] === ',' && !unclosedString && (queryArray[i] = ', ');
-      
+
       // Consider code inside curly brackets as Groovy
       if (queryArray[i] === '{') {
         unclosedCurlyBracketCount++;
@@ -89,54 +106,80 @@
       }
 
       // The code should be considered Gremlin if all curly brackets are closed only if there is an unfinished g.V() or g.E()
-      (queryArray.slice(i, i+4).join('') === 'g.V(' || queryArray.slice(i, i+4).join('') === 'g.E(') && (isGremlin = true);
+      (queryArray.slice(i, i + 4).join('') === 'g.V(' ||
+        queryArray.slice(i, i + 4).join('') === 'g.E(') &&
+        (isGremlin = true);
 
       // Handle start of comment
-      if (!unclosedComment && queryArray.slice(i, i+2).join('') === '//') {
+      if (!unclosedComment && queryArray.slice(i, i + 2).join('') === '//') {
         unclosedComment = '//';
-        
+
         // Add grey color
         queryArray[i] = "<span style='color:LightGray;'>" + queryArray[i];
-        
+
         // Add space before double slash comment start if there aren't any
-        if (i !== 0 && queryArray[i-1] !== '' && queryArray[i-1].substring(queryArray[i-1].length-4) !== '<br>' && queryArray[i-1].substring(queryArray[i-1].length-6) !== '&nbsp;') {
-          queryArray[i-1] += '&nbsp;';
+        if (
+          i !== 0 &&
+          queryArray[i - 1] !== '' &&
+          queryArray[i - 1].substring(queryArray[i - 1].length - 4) !==
+            '<br>' &&
+          queryArray[i - 1].substring(queryArray[i - 1].length - 6) !== '&nbsp;'
+        ) {
+          queryArray[i - 1] += '&nbsp;';
         }
 
         // Add space after double slash comment start if there aren't any
-        if (queryArray[i+2] !== ' ' && queryArray[i+2] !== '&nbsp;') {
-          queryArray[i+1] += '&nbsp;';
+        if (queryArray[i + 2] !== ' ' && queryArray[i + 2] !== '&nbsp;') {
+          queryArray[i + 1] += '&nbsp;';
         }
+      } else if (
+        !unclosedComment &&
+        queryArray.slice(i, i + 2).join('') === '/*'
+      ) {
+        unclosedComment = '/*';
 
-      } else if (!unclosedComment && queryArray.slice(i, i+2).join('') === '/*') {
-        unclosedComment = '/*'
-        
         // Add grey color
         queryArray[i] = "<span style='color:LightGray;'>" + queryArray[i];
 
         // Add space before start of multi-line comment if there aren't any
-        if (i !== 0 && queryArray[i-1] !== '' && queryArray[i-1].substring(queryArray[i-1].length-4) !== '<br>' && queryArray[i-1].substring(queryArray[i-1].length-6) !== '&nbsp;') {
-          queryArray[i-1] += '&nbsp;';
+        if (
+          i !== 0 &&
+          queryArray[i - 1] !== '' &&
+          queryArray[i - 1].substring(queryArray[i - 1].length - 4) !==
+            '<br>' &&
+          queryArray[i - 1].substring(queryArray[i - 1].length - 6) !== '&nbsp;'
+        ) {
+          queryArray[i - 1] += '&nbsp;';
         }
 
         // Add space after start of multi-line comment if there aren't any
-        if (queryArray[i+2] !== ' ' && queryArray[i+2] !== '&nbsp;') {
-          queryArray[i+1] += '&nbsp;';
+        if (queryArray[i + 2] !== ' ' && queryArray[i + 2] !== '&nbsp;') {
+          queryArray[i + 1] += '&nbsp;';
         }
       }
 
       // Handle end of comment
       if (unclosedComment === '//' && queryArray[i] === '\n') {
-          unclosedComment = false;
-          queryArray[i] += '</span><br>' + spaces(2*unclosedParenthesisCount+6*gDotV.length);
+        unclosedComment = false;
+        queryArray[i] +=
+          '</span><br>' +
+          spaces(2 * unclosedParenthesisCount + 6 * gDotV.length);
       } else if (unclosedComment === '/*') {
         if (queryArray[i] === '\n') {
-          queryArray[i] += '<br>' + spaces(2*unclosedParenthesisCount+6*gDotV.length);
-        } else if (queryArray.slice(i-1, i+1).join('') === '*/') {
+          queryArray[i] +=
+            '<br>' + spaces(2 * unclosedParenthesisCount + 6 * gDotV.length);
+        } else if (queryArray.slice(i - 1, i + 1).join('') === '*/') {
           unclosedComment = false;
           queryArray[i] += '</span>';
-          if (queryArray[i-2].substring(queryArray[i-2].length-6) !== '&nbsp;' && queryArray[i-2].substring(queryArray[i-2].length-1) !== ' ' && queryArray[i-2].substring(queryArray[i-2].length-4) !== '<br>' && queryArray[i-2] !== '') {
-            queryArray[i-2] += '&nbsp;';
+          if (
+            queryArray[i - 2].substring(queryArray[i - 2].length - 6) !==
+              '&nbsp;' &&
+            queryArray[i - 2].substring(queryArray[i - 2].length - 1) !== ' ' &&
+            queryArray[i - 2].substring(queryArray[i - 2].length - 4) !==
+              '<br>' &&
+            queryArray[i - 2] !== ''
+          ) {
+            queryArray[i - 2] += '&nbsp;';
           }
         }
       }
@@ -146,102 +189,378 @@
       ------------------------------------------------------------------------*/
 
       if (!isGremlin && !unclosedComment) {
-
         // Preserve linebreaks
         !unclosedString && queryArray[i] === '\n' && (queryArray[i] = '<br>');
-        
+
         // Preserve spaces
         queryArray[i] === ' ' && (queryArray[i] = '&nbsp;');
-        
+
         // Color Groovy reserved keywords which are not part of a comment
-        if (!unclosedComment && !isAlphabetical(queryArray[i-1])) {
-          queryArray.slice(i, i+8).join('') === 'abstract' && !isAlphabetical(queryArray[i+8]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+7] += '</span>');
-          queryArray.slice(i, i+2).join('') === 'as' && !isAlphabetical(queryArray[i+2]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+1] += '</span>');
-          queryArray.slice(i, i+6).join('') === 'assert' && !isAlphabetical(queryArray[i+6]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+5] += '</span>');
-          queryArray.slice(i, i+7).join('') === 'boolean' && !isAlphabetical(queryArray[i+7]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+6] += '</span>');
-          queryArray.slice(i, i+5).join('') === 'break' && !isAlphabetical(queryArray[i+5]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+4] += '</span>');
-          queryArray.slice(i, i+4).join('') === 'byte' && !isAlphabetical(queryArray[i+4]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+3] += '</span>');
-          queryArray.slice(i, i+4).join('') === 'case' && !isAlphabetical(queryArray[i+4]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+3] += '</span>');
-          queryArray.slice(i, i+5).join('') === 'catch' && !isAlphabetical(queryArray[i+5]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+4] += '</span>');
-          queryArray.slice(i, i+4).join('') === 'char' && !isAlphabetical(queryArray[i+4]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+3] += '</span>');
-          queryArray.slice(i, i+5).join('') === 'class' && !isAlphabetical(queryArray[i+5]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+4] += '</span>');
-          queryArray.slice(i, i+5).join('') === 'const' && !isAlphabetical(queryArray[i+5]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+4] += '</span>');
-          queryArray.slice(i, i+8).join('') === 'continue' && !isAlphabetical(queryArray[i+8]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+7] += '</span>');
-          queryArray.slice(i, i+3).join('') === 'def' && !isAlphabetical(queryArray[i+3]) && (queryArray[i] = "<span style='color:DeepPink;'>" + queryArray[i]) && (queryArray[i+2] += '</span>');
-          queryArray.slice(i, i+7).join('') === 'default' && !isAlphabetical(queryArray[i+7]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+6] += '</span>');
-          queryArray.slice(i, i+2).join('') === 'do' && !isAlphabetical(queryArray[i+2]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+1] += '</span>');
-          queryArray.slice(i, i+6).join('') === 'double' && !isAlphabetical(queryArray[i+6]) && (queryArray[i] = "<span style='color:DeepPink;'>" + queryArray[i]) && (queryArray[i+5] += '</span>');
-          queryArray.slice(i, i+4).join('') === 'else' && !isAlphabetical(queryArray[i+4]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+3] += '</span>');
-          queryArray.slice(i, i+4).join('') === 'enum' && !isAlphabetical(queryArray[i+4]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+3] += '</span>');
-          queryArray.slice(i, i+7).join('') === 'extends' && !isAlphabetical(queryArray[i+7]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+6] += '</span>');
-          queryArray.slice(i, i+5).join('') === 'false' && !isAlphabetical(queryArray[i+5]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+4] += '</span>');
-          queryArray.slice(i, i+5).join('') === 'final' && !isAlphabetical(queryArray[i+5]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+4] += '</span>');
-          queryArray.slice(i, i+7).join('') === 'finally' && !isAlphabetical(queryArray[i+7]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+6] += '</span>');
-          queryArray.slice(i, i+5).join('') === 'float' && !isAlphabetical(queryArray[i+5]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+4] += '</span>');
-          queryArray.slice(i, i+3).join('') === 'for' && !isAlphabetical(queryArray[i+3]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+2] += '</span>');
-          queryArray.slice(i, i+4).join('') === 'goto' && !isAlphabetical(queryArray[i+4]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+3] += '</span>');
-          queryArray.slice(i, i+2).join('') === 'if' && !isAlphabetical(queryArray[i+2]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+1] += '</span>');
-          queryArray.slice(i, i+10).join('') === 'implements' && !isAlphabetical(queryArray[i+10]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+9] += '</span>');
-          queryArray.slice(i, i+6).join('') === 'import' && !isAlphabetical(queryArray[i+6]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+5] += '</span>');
-          queryArray.slice(i, i+2).join('') === 'in' && !isAlphabetical(queryArray[i+2]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+1] += '</span>');
-          queryArray.slice(i, i+10).join('') === 'instanceof' && !isAlphabetical(queryArray[i+10]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+9] += '</span>');
-          queryArray.slice(i, i+3).join('') === 'int' && !isAlphabetical(queryArray[i+3]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+2] += '</span>');
-          queryArray.slice(i, i+9).join('') === 'interface' && !isAlphabetical(queryArray[i+9]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+8] += '</span>');
-          queryArray.slice(i, i+4).join('') === 'long' && !isAlphabetical(queryArray[i+4]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+3] += '</span>');
-          queryArray.slice(i, i+6).join('') === 'native' && !isAlphabetical(queryArray[i+6]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+5] += '</span>');
-          queryArray.slice(i, i+3).join('') === 'new' && !isAlphabetical(queryArray[i+3]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+2] += '</span>');
-          queryArray.slice(i, i+4).join('') === 'null' && !isAlphabetical(queryArray[i+4]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+3] += '</span>');
-          queryArray.slice(i, i+7).join('') === 'package' && !isAlphabetical(queryArray[i+7]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+6] += '</span>');
-          queryArray.slice(i, i+7).join('') === 'private' && !isAlphabetical(queryArray[i+7]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+6] += '</span>');
-          queryArray.slice(i, i+9).join('') === 'protected' && !isAlphabetical(queryArray[i+9]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+8] += '</span>');
-          queryArray.slice(i, i+6).join('') === 'public' && !isAlphabetical(queryArray[i+6]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+5] += '</span>');
-          queryArray.slice(i, i+6).join('') === 'return' && !isAlphabetical(queryArray[i+6]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+5] += '</span>');
-          queryArray.slice(i, i+5).join('') === 'short' && !isAlphabetical(queryArray[i+5]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+4] += '</span>');
-          queryArray.slice(i, i+6).join('') === 'static' && !isAlphabetical(queryArray[i+6]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+5] += '</span>');
-          queryArray.slice(i, i+8).join('') === 'strictfp' && !isAlphabetical(queryArray[i+8]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+7] += '</span>');
-          queryArray.slice(i, i+5).join('') === 'super' && !isAlphabetical(queryArray[i+5]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+4] += '</span>');
-          queryArray.slice(i, i+6).join('') === 'switch' && !isAlphabetical(queryArray[i+6]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+5] += '</span>');
-          queryArray.slice(i, i+12).join('') === 'synchronized' && !isAlphabetical(queryArray[i+12]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+11] += '</span>');
-          queryArray.slice(i, i+4).join('') === 'this' && !isAlphabetical(queryArray[i+4]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+3] += '</span>');
-          queryArray.slice(i, i+10).join('') === 'threadsafe' && !isAlphabetical(queryArray[i+10]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+9] += '</span>');
-          queryArray.slice(i, i+5).join('') === 'throw' && !isAlphabetical(queryArray[i+5]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+4] += '</span>');
-          queryArray.slice(i, i+6).join('') === 'throws' && !isAlphabetical(queryArray[i+6]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+5] += '</span>');
-          queryArray.slice(i, i+9).join('') === 'transient' && !isAlphabetical(queryArray[i+9]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+8] += '</span>');
-          queryArray.slice(i, i+4).join('') === 'true' && !isAlphabetical(queryArray[i+4]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+3] += '</span>');
-          queryArray.slice(i, i+3).join('') === 'try' && !isAlphabetical(queryArray[i+3]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+2] += '</span>');
-          queryArray.slice(i, i+4).join('') === 'void' && !isAlphabetical(queryArray[i+4]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+3] += '</span>');
-          queryArray.slice(i, i+8).join('') === 'volatile' && !isAlphabetical(queryArray[i+8]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+7] += '</span>');
-          queryArray.slice(i, i+5).join('') === 'while' && !isAlphabetical(queryArray[i+5]) && (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) && (queryArray[i+4] += '</span>');
+        if (!unclosedComment && !isAlphabetical(queryArray[i - 1])) {
+          queryArray.slice(i, i + 8).join('') === 'abstract' &&
+            !isAlphabetical(queryArray[i + 8]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 7] += '</span>');
+          queryArray.slice(i, i + 2).join('') === 'as' &&
+            !isAlphabetical(queryArray[i + 2]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 1] += '</span>');
+          queryArray.slice(i, i + 6).join('') === 'assert' &&
+            !isAlphabetical(queryArray[i + 6]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 5] += '</span>');
+          queryArray.slice(i, i + 7).join('') === 'boolean' &&
+            !isAlphabetical(queryArray[i + 7]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 6] += '</span>');
+          queryArray.slice(i, i + 5).join('') === 'break' &&
+            !isAlphabetical(queryArray[i + 5]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 4] += '</span>');
+          queryArray.slice(i, i + 4).join('') === 'byte' &&
+            !isAlphabetical(queryArray[i + 4]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 3] += '</span>');
+          queryArray.slice(i, i + 4).join('') === 'case' &&
+            !isAlphabetical(queryArray[i + 4]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 3] += '</span>');
+          queryArray.slice(i, i + 5).join('') === 'catch' &&
+            !isAlphabetical(queryArray[i + 5]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 4] += '</span>');
+          queryArray.slice(i, i + 4).join('') === 'char' &&
+            !isAlphabetical(queryArray[i + 4]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 3] += '</span>');
+          queryArray.slice(i, i + 5).join('') === 'class' &&
+            !isAlphabetical(queryArray[i + 5]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 4] += '</span>');
+          queryArray.slice(i, i + 5).join('') === 'const' &&
+            !isAlphabetical(queryArray[i + 5]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 4] += '</span>');
+          queryArray.slice(i, i + 8).join('') === 'continue' &&
+            !isAlphabetical(queryArray[i + 8]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 7] += '</span>');
+          queryArray.slice(i, i + 3).join('') === 'def' &&
+            !isAlphabetical(queryArray[i + 3]) &&
+            (queryArray[i] =
+              "<span style='color:DeepPink;'>" + queryArray[i]) &&
+            (queryArray[i + 2] += '</span>');
+          queryArray.slice(i, i + 7).join('') === 'default' &&
+            !isAlphabetical(queryArray[i + 7]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 6] += '</span>');
+          queryArray.slice(i, i + 2).join('') === 'do' &&
+            !isAlphabetical(queryArray[i + 2]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 1] += '</span>');
+          queryArray.slice(i, i + 6).join('') === 'double' &&
+            !isAlphabetical(queryArray[i + 6]) &&
+            (queryArray[i] =
+              "<span style='color:DeepPink;'>" + queryArray[i]) &&
+            (queryArray[i + 5] += '</span>');
+          queryArray.slice(i, i + 4).join('') === 'else' &&
+            !isAlphabetical(queryArray[i + 4]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 3] += '</span>');
+          queryArray.slice(i, i + 4).join('') === 'enum' &&
+            !isAlphabetical(queryArray[i + 4]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 3] += '</span>');
+          queryArray.slice(i, i + 7).join('') === 'extends' &&
+            !isAlphabetical(queryArray[i + 7]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 6] += '</span>');
+          queryArray.slice(i, i + 5).join('') === 'false' &&
+            !isAlphabetical(queryArray[i + 5]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 4] += '</span>');
+          queryArray.slice(i, i + 5).join('') === 'final' &&
+            !isAlphabetical(queryArray[i + 5]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 4] += '</span>');
+          queryArray.slice(i, i + 7).join('') === 'finally' &&
+            !isAlphabetical(queryArray[i + 7]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 6] += '</span>');
+          queryArray.slice(i, i + 5).join('') === 'float' &&
+            !isAlphabetical(queryArray[i + 5]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 4] += '</span>');
+          queryArray.slice(i, i + 3).join('') === 'for' &&
+            !isAlphabetical(queryArray[i + 3]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 2] += '</span>');
+          queryArray.slice(i, i + 4).join('') === 'goto' &&
+            !isAlphabetical(queryArray[i + 4]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 3] += '</span>');
+          queryArray.slice(i, i + 2).join('') === 'if' &&
+            !isAlphabetical(queryArray[i + 2]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 1] += '</span>');
+          queryArray.slice(i, i + 10).join('') === 'implements' &&
+            !isAlphabetical(queryArray[i + 10]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 9] += '</span>');
+          queryArray.slice(i, i + 6).join('') === 'import' &&
+            !isAlphabetical(queryArray[i + 6]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 5] += '</span>');
+          queryArray.slice(i, i + 2).join('') === 'in' &&
+            !isAlphabetical(queryArray[i + 2]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 1] += '</span>');
+          queryArray.slice(i, i + 10).join('') === 'instanceof' &&
+            !isAlphabetical(queryArray[i + 10]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 9] += '</span>');
+          queryArray.slice(i, i + 3).join('') === 'int' &&
+            !isAlphabetical(queryArray[i + 3]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 2] += '</span>');
+          queryArray.slice(i, i + 9).join('') === 'interface' &&
+            !isAlphabetical(queryArray[i + 9]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 8] += '</span>');
+          queryArray.slice(i, i + 4).join('') === 'long' &&
+            !isAlphabetical(queryArray[i + 4]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 3] += '</span>');
+          queryArray.slice(i, i + 6).join('') === 'native' &&
+            !isAlphabetical(queryArray[i + 6]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 5] += '</span>');
+          queryArray.slice(i, i + 3).join('') === 'new' &&
+            !isAlphabetical(queryArray[i + 3]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 2] += '</span>');
+          queryArray.slice(i, i + 4).join('') === 'null' &&
+            !isAlphabetical(queryArray[i + 4]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 3] += '</span>');
+          queryArray.slice(i, i + 7).join('') === 'package' &&
+            !isAlphabetical(queryArray[i + 7]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 6] += '</span>');
+          queryArray.slice(i, i + 7).join('') === 'private' &&
+            !isAlphabetical(queryArray[i + 7]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 6] += '</span>');
+          queryArray.slice(i, i + 9).join('') === 'protected' &&
+            !isAlphabetical(queryArray[i + 9]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 8] += '</span>');
+          queryArray.slice(i, i + 6).join('') === 'public' &&
+            !isAlphabetical(queryArray[i + 6]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 5] += '</span>');
+          queryArray.slice(i, i + 6).join('') === 'return' &&
+            !isAlphabetical(queryArray[i + 6]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 5] += '</span>');
+          queryArray.slice(i, i + 5).join('') === 'short' &&
+            !isAlphabetical(queryArray[i + 5]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 4] += '</span>');
+          queryArray.slice(i, i + 6).join('') === 'static' &&
+            !isAlphabetical(queryArray[i + 6]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 5] += '</span>');
+          queryArray.slice(i, i + 8).join('') === 'strictfp' &&
+            !isAlphabetical(queryArray[i + 8]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 7] += '</span>');
+          queryArray.slice(i, i + 5).join('') === 'super' &&
+            !isAlphabetical(queryArray[i + 5]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 4] += '</span>');
+          queryArray.slice(i, i + 6).join('') === 'switch' &&
+            !isAlphabetical(queryArray[i + 6]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 5] += '</span>');
+          queryArray.slice(i, i + 12).join('') === 'synchronized' &&
+            !isAlphabetical(queryArray[i + 12]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 11] += '</span>');
+          queryArray.slice(i, i + 4).join('') === 'this' &&
+            !isAlphabetical(queryArray[i + 4]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 3] += '</span>');
+          queryArray.slice(i, i + 10).join('') === 'threadsafe' &&
+            !isAlphabetical(queryArray[i + 10]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 9] += '</span>');
+          queryArray.slice(i, i + 5).join('') === 'throw' &&
+            !isAlphabetical(queryArray[i + 5]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 4] += '</span>');
+          queryArray.slice(i, i + 6).join('') === 'throws' &&
+            !isAlphabetical(queryArray[i + 6]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 5] += '</span>');
+          queryArray.slice(i, i + 9).join('') === 'transient' &&
+            !isAlphabetical(queryArray[i + 9]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 8] += '</span>');
+          queryArray.slice(i, i + 4).join('') === 'true' &&
+            !isAlphabetical(queryArray[i + 4]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 3] += '</span>');
+          queryArray.slice(i, i + 3).join('') === 'try' &&
+            !isAlphabetical(queryArray[i + 3]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 2] += '</span>');
+          queryArray.slice(i, i + 4).join('') === 'void' &&
+            !isAlphabetical(queryArray[i + 4]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 3] += '</span>');
+          queryArray.slice(i, i + 8).join('') === 'volatile' &&
+            !isAlphabetical(queryArray[i + 8]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 7] += '</span>');
+          queryArray.slice(i, i + 5).join('') === 'while' &&
+            !isAlphabetical(queryArray[i + 5]) &&
+            (queryArray[i] = "<span style='color:Purple;'>" + queryArray[i]) &&
+            (queryArray[i + 4] += '</span>');
 
           // Dark violet
-          queryArray.slice(i, i+11).join('') === 'DEFAULTLANG' && !isAlphabetical(queryArray[i+11]) && (queryArray[i] = "<span style='color:DarkViolet;'>" + queryArray[i]) && (queryArray[i+10] += '</span>');
-          queryArray.slice(i, i+12).join('') === 'MILLISECONDS' && !isAlphabetical(queryArray[i+12]) && (queryArray[i] = "<span style='color:DarkViolet;'>" + queryArray[i]) && (queryArray[i+11] += '</span>');
-          queryArray.slice(i, i+7).join('') === 'SECONDS' && !isAlphabetical(queryArray[i+7]) && (queryArray[i] = "<span style='color:DarkViolet;'>" + queryArray[i]) && (queryArray[i+6] += '</span>');
-          queryArray.slice(i, i+7).join('') === 'MINUTES' && !isAlphabetical(queryArray[i+7]) && (queryArray[i] = "<span style='color:DarkViolet;'>" + queryArray[i]) && (queryArray[i+6] += '</span>');
-          queryArray.slice(i, i+5).join('') === 'HOURS' && !isAlphabetical(queryArray[i+5]) && (queryArray[i] = "<span style='color:DarkViolet;'>" + queryArray[i]) && (queryArray[i+4] += '</span>');
-          queryArray.slice(i, i+4).join('') === 'DAYS' && !isAlphabetical(queryArray[i+4]) && (queryArray[i] = "<span style='color:DarkViolet;'>" + queryArray[i]) && (queryArray[i+3] += '</span>');
-          queryArray.slice(i, i+5).join('') === 'WEEKS' && !isAlphabetical(queryArray[i+5]) && (queryArray[i] = "<span style='color:DarkViolet;'>" + queryArray[i]) && (queryArray[i+4] += '</span>');
-          queryArray.slice(i, i+6).join('') === 'MONTHS' && !isAlphabetical(queryArray[i+6]) && (queryArray[i] = "<span style='color:DarkViolet;'>" + queryArray[i]) && (queryArray[i+5] += '</span>');
-          queryArray.slice(i, i+5).join('') === 'YEARS' && !isAlphabetical(queryArray[i+5]) && (queryArray[i] = "<span style='color:DarkViolet;'>" + queryArray[i]) && (queryArray[i+4] += '</span>');
-          queryArray.slice(i, i+18).join('') === 'DATEFORMAT_DEFAULT' && !isAlphabetical(queryArray[i+18]) && (queryArray[i] = "<span style='color:DarkViolet;'>" + queryArray[i]) && (queryArray[i+17] += '</span>');
+          queryArray.slice(i, i + 11).join('') === 'DEFAULTLANG' &&
+            !isAlphabetical(queryArray[i + 11]) &&
+            (queryArray[i] =
+              "<span style='color:DarkViolet;'>" + queryArray[i]) &&
+            (queryArray[i + 10] += '</span>');
+          queryArray.slice(i, i + 12).join('') === 'MILLISECONDS' &&
+            !isAlphabetical(queryArray[i + 12]) &&
+            (queryArray[i] =
+              "<span style='color:DarkViolet;'>" + queryArray[i]) &&
+            (queryArray[i + 11] += '</span>');
+          queryArray.slice(i, i + 7).join('') === 'SECONDS' &&
+            !isAlphabetical(queryArray[i + 7]) &&
+            (queryArray[i] =
+              "<span style='color:DarkViolet;'>" + queryArray[i]) &&
+            (queryArray[i + 6] += '</span>');
+          queryArray.slice(i, i + 7).join('') === 'MINUTES' &&
+            !isAlphabetical(queryArray[i + 7]) &&
+            (queryArray[i] =
+              "<span style='color:DarkViolet;'>" + queryArray[i]) &&
+            (queryArray[i + 6] += '</span>');
+          queryArray.slice(i, i + 5).join('') === 'HOURS' &&
+            !isAlphabetical(queryArray[i + 5]) &&
+            (queryArray[i] =
+              "<span style='color:DarkViolet;'>" + queryArray[i]) &&
+            (queryArray[i + 4] += '</span>');
+          queryArray.slice(i, i + 4).join('') === 'DAYS' &&
+            !isAlphabetical(queryArray[i + 4]) &&
+            (queryArray[i] =
+              "<span style='color:DarkViolet;'>" + queryArray[i]) &&
+            (queryArray[i + 3] += '</span>');
+          queryArray.slice(i, i + 5).join('') === 'WEEKS' &&
+            !isAlphabetical(queryArray[i + 5]) &&
+            (queryArray[i] =
+              "<span style='color:DarkViolet;'>" + queryArray[i]) &&
+            (queryArray[i + 4] += '</span>');
+          queryArray.slice(i, i + 6).join('') === 'MONTHS' &&
+            !isAlphabetical(queryArray[i + 6]) &&
+            (queryArray[i] =
+              "<span style='color:DarkViolet;'>" + queryArray[i]) &&
+            (queryArray[i + 5] += '</span>');
+          queryArray.slice(i, i + 5).join('') === 'YEARS' &&
+            !isAlphabetical(queryArray[i + 5]) &&
+            (queryArray[i] =
+              "<span style='color:DarkViolet;'>" + queryArray[i]) &&
+            (queryArray[i + 4] += '</span>');
+          queryArray.slice(i, i + 18).join('') === 'DATEFORMAT_DEFAULT' &&
+            !isAlphabetical(queryArray[i + 18]) &&
+            (queryArray[i] =
+              "<span style='color:DarkViolet;'>" + queryArray[i]) &&
+            (queryArray[i + 17] += '</span>');
 
           // Color Groovy classes
-          queryArray.slice(i, i+4).join('') === 'Math' && !isAlphabetical(queryArray[i+4]) && (queryArray[i] = "<span style='color:DeepSkyBlue;'>" + queryArray[i]) && (queryArray[i+3] += '</span>');
-          queryArray.slice(i, i+7).join('') === 'Integer' && !isAlphabetical(queryArray[i+7]) && (queryArray[i] = "<span style='color:DeepSkyBlue;'>" + queryArray[i]) && (queryArray[i+6] += '</span>');
-          queryArray.slice(i, i+5).join('') === 'Float' && !isAlphabetical(queryArray[i+5]) && (queryArray[i] = "<span style='color:DeepSkyBlue;'>" + queryArray[i]) && (queryArray[i+4] += '</span>');
-          queryArray.slice(i, i+6).join('') === 'Double' && !isAlphabetical(queryArray[i+6]) && (queryArray[i] = "<span style='color:DeepSkyBlue;'>" + queryArray[i]) && (queryArray[i+5] += '</span>');
-          queryArray.slice(i, i+4).join('') === 'Long' && !isAlphabetical(queryArray[i+4]) && (queryArray[i] = "<span style='color:DeepSkyBlue;'>" + queryArray[i]) && (queryArray[i+3] += '</span>');
-          queryArray.slice(i, i+10).join('') === 'BigDecimal' && !isAlphabetical(queryArray[i+10]) && (queryArray[i] = "<span style='color:DeepSkyBlue;'>" + queryArray[i]) && (queryArray[i+9] += '</span>');
-          queryArray.slice(i, i+4).join('') === 'Date' && !isAlphabetical(queryArray[i+4]) && (queryArray[i] = "<span style='color:DeepSkyBlue;'>" + queryArray[i]) && (queryArray[i+3] += '</span>');
-          queryArray.slice(i, i+7).join('') === 'Geocode' && !isAlphabetical(queryArray[i+7]) && (queryArray[i] = "<span style='color:DeepSkyBlue;'>" + queryArray[i]) && (queryArray[i+6] += '</span>');
-          queryArray.slice(i, i+6).join('') === 'Object' && !isAlphabetical(queryArray[i+6]) && (queryArray[i] = "<span style='color:DeepSkyBlue;'>" + queryArray[i]) && (queryArray[i+5] += '</span>');
-          queryArray.slice(i, i+7).join('') === 'Closure' && !isAlphabetical(queryArray[i+7]) && (queryArray[i] = "<span style='color:DeepSkyBlue;'>" + queryArray[i]) && (queryArray[i+6] += '</span>');
-          queryArray.slice(i, i+6).join('') === 'String' && !isAlphabetical(queryArray[i+6]) && (queryArray[i] = "<span style='color:DeepSkyBlue;'>" + queryArray[i]) && (queryArray[i+5] += '</span>');
-          queryArray.slice(i, i+3).join('') === 'Set' && !isAlphabetical(queryArray[i+3]) && (queryArray[i] = "<span style='color:DeepSkyBlue;'>" + queryArray[i]) && (queryArray[i+2] += '</span>');
-          queryArray.slice(i, i+5).join('') === 'Array' && !isAlphabetical(queryArray[i+5]) && (queryArray[i] = "<span style='color:DeepSkyBlue;'>" + queryArray[i]) && (queryArray[i+4] += '</span>');
-          queryArray.slice(i, i+13).join('') === 'InvokerHelper' && !isAlphabetical(queryArray[i+13]) && (queryArray[i] = "<span style='color:DeepSkyBlue;'>" + queryArray[i]) && (queryArray[i+12] += '</span>');
-          queryArray.slice(i, i+9).join('') === 'Exception' && !isAlphabetical(queryArray[i+9]) && (queryArray[i] = "<span style='color:DeepSkyBlue;'>" + queryArray[i]) && (queryArray[i+8] += '</span>');
-          queryArray.slice(i, i+10).join('') === 'Rowbinding' && !isAlphabetical(queryArray[i+10]) && (queryArray[i] = "<span style='color:DeepSkyBlue;'>" + queryArray[i]) && (queryArray[i+9] += '</span>');
+          queryArray.slice(i, i + 4).join('') === 'Math' &&
+            !isAlphabetical(queryArray[i + 4]) &&
+            (queryArray[i] =
+              "<span style='color:DeepSkyBlue;'>" + queryArray[i]) &&
+            (queryArray[i + 3] += '</span>');
+          queryArray.slice(i, i + 7).join('') === 'Integer' &&
+            !isAlphabetical(queryArray[i + 7]) &&
+            (queryArray[i] =
+              "<span style='color:DeepSkyBlue;'>" + queryArray[i]) &&
+            (queryArray[i + 6] += '</span>');
+          queryArray.slice(i, i + 5).join('') === 'Float' &&
+            !isAlphabetical(queryArray[i + 5]) &&
+            (queryArray[i] =
+              "<span style='color:DeepSkyBlue;'>" + queryArray[i]) &&
+            (queryArray[i + 4] += '</span>');
+          queryArray.slice(i, i + 6).join('') === 'Double' &&
+            !isAlphabetical(queryArray[i + 6]) &&
+            (queryArray[i] =
+              "<span style='color:DeepSkyBlue;'>" + queryArray[i]) &&
+            (queryArray[i + 5] += '</span>');
+          queryArray.slice(i, i + 4).join('') === 'Long' &&
+            !isAlphabetical(queryArray[i + 4]) &&
+            (queryArray[i] =
+              "<span style='color:DeepSkyBlue;'>" + queryArray[i]) &&
+            (queryArray[i + 3] += '</span>');
+          queryArray.slice(i, i + 10).join('') === 'BigDecimal' &&
+            !isAlphabetical(queryArray[i + 10]) &&
+            (queryArray[i] =
+              "<span style='color:DeepSkyBlue;'>" + queryArray[i]) &&
+            (queryArray[i + 9] += '</span>');
+          queryArray.slice(i, i + 4).join('') === 'Date' &&
+            !isAlphabetical(queryArray[i + 4]) &&
+            (queryArray[i] =
+              "<span style='color:DeepSkyBlue;'>" + queryArray[i]) &&
+            (queryArray[i + 3] += '</span>');
+          queryArray.slice(i, i + 7).join('') === 'Geocode' &&
+            !isAlphabetical(queryArray[i + 7]) &&
+            (queryArray[i] =
+              "<span style='color:DeepSkyBlue;'>" + queryArray[i]) &&
+            (queryArray[i + 6] += '</span>');
+          queryArray.slice(i, i + 6).join('') === 'Object' &&
+            !isAlphabetical(queryArray[i + 6]) &&
+            (queryArray[i] =
+              "<span style='color:DeepSkyBlue;'>" + queryArray[i]) &&
+            (queryArray[i + 5] += '</span>');
+          queryArray.slice(i, i + 7).join('') === 'Closure' &&
+            !isAlphabetical(queryArray[i + 7]) &&
+            (queryArray[i] =
+              "<span style='color:DeepSkyBlue;'>" + queryArray[i]) &&
+            (queryArray[i + 6] += '</span>');
+          queryArray.slice(i, i + 6).join('') === 'String' &&
+            !isAlphabetical(queryArray[i + 6]) &&
+            (queryArray[i] =
+              "<span style='color:DeepSkyBlue;'>" + queryArray[i]) &&
+            (queryArray[i + 5] += '</span>');
+          queryArray.slice(i, i + 3).join('') === 'Set' &&
+            !isAlphabetical(queryArray[i + 3]) &&
+            (queryArray[i] =
+              "<span style='color:DeepSkyBlue;'>" + queryArray[i]) &&
+            (queryArray[i + 2] += '</span>');
+          queryArray.slice(i, i + 5).join('') === 'Array' &&
+            !isAlphabetical(queryArray[i + 5]) &&
+            (queryArray[i] =
+              "<span style='color:DeepSkyBlue;'>" + queryArray[i]) &&
+            (queryArray[i + 4] += '</span>');
+          queryArray.slice(i, i + 13).join('') === 'InvokerHelper' &&
+            !isAlphabetical(queryArray[i + 13]) &&
+            (queryArray[i] =
+              "<span style='color:DeepSkyBlue;'>" + queryArray[i]) &&
+            (queryArray[i + 12] += '</span>');
+          queryArray.slice(i, i + 9).join('') === 'Exception' &&
+            !isAlphabetical(queryArray[i + 9]) &&
+            (queryArray[i] =
+              "<span style='color:DeepSkyBlue;'>" + queryArray[i]) &&
+            (queryArray[i + 8] += '</span>');
+          queryArray.slice(i, i + 10).join('') === 'Rowbinding' &&
+            !isAlphabetical(queryArray[i + 10]) &&
+            (queryArray[i] =
+              "<span style='color:DeepSkyBlue;'>" + queryArray[i]) &&
+            (queryArray[i + 9] += '</span>');
         }
       }
 
@@ -250,42 +569,82 @@
       ------------------------------------------------------------------------*/
 
       if (isGremlin && unclosedComment !== '//') {
-
         // Remove any spaces and newlines
-        !unclosedComment && !unclosedString && (queryArray[i] === ' ' || queryArray[i] === '\n' || queryArray[i] === '&nbsp;') && (queryArray[i] = '');
+        !unclosedComment &&
+          !unclosedString &&
+          (queryArray[i] === ' ' ||
+            queryArray[i] === '\n' ||
+            queryArray[i] === '&nbsp;') &&
+          (queryArray[i] = '');
 
         if (queryArray[i] === '.') {
-          (queryArray[i-5] + queryArray[i-4] + queryArray[i-3] + queryArray[i-2] + queryArray[i-1] === 'g.V()' ||
-          queryArray[i-5] + queryArray[i-4] + queryArray[i-3] + queryArray[i-2] + queryArray[i-1] === 'g.E()') &&
-          (gDotV.push(unclosedParenthesisCount));
-        
+          (queryArray[i - 5] +
+            queryArray[i - 4] +
+            queryArray[i - 3] +
+            queryArray[i - 2] +
+            queryArray[i - 1] ===
+            'g.V()' ||
+            queryArray[i - 5] +
+              queryArray[i - 4] +
+              queryArray[i - 3] +
+              queryArray[i - 2] +
+              queryArray[i - 1] ===
+              'g.E()') &&
+            gDotV.push(unclosedParenthesisCount);
+
           // Add punctuation newline for each dot after g.V() or g.E()
-          (queryArray[i-1] !== 'g' || queryArray[i+1] + queryArray[i+2] + queryArray[i+3] !== 'V()') &&
-          (queryArray[i-1] !== 'g' || queryArray[i+1] + queryArray[i+2] + queryArray[i+3] !== 'E()') &&
-          queryArray[i-5] + queryArray[i-4] + queryArray[i-3] + queryArray[i-2] + queryArray[i-1] !== 'g.V()' &&
-          queryArray[i-5] + queryArray[i-4] + queryArray[i-3] + queryArray[i-2] + queryArray[i-1] !== 'g.E()' &&
-          (queryArray[i] += '<br>' + spaces(2*unclosedParenthesisCount+6*gDotV.length));
+          (queryArray[i - 1] !== 'g' ||
+            queryArray[i + 1] + queryArray[i + 2] + queryArray[i + 3] !==
+              'V()') &&
+            (queryArray[i - 1] !== 'g' ||
+              queryArray[i + 1] + queryArray[i + 2] + queryArray[i + 3] !==
+                'E()') &&
+            queryArray[i - 5] +
+              queryArray[i - 4] +
+              queryArray[i - 3] +
+              queryArray[i - 2] +
+              queryArray[i - 1] !==
+              'g.V()' &&
+            queryArray[i - 5] +
+              queryArray[i - 4] +
+              queryArray[i - 3] +
+              queryArray[i - 2] +
+              queryArray[i - 1] !==
+              'g.E()' &&
+            (queryArray[i] +=
+              '<br>' + spaces(2 * unclosedParenthesisCount + 6 * gDotV.length));
         }
         // Only consider parenthesis newlines after g.V() or g.E().
         if (gDotV.length) {
-        
           // Check if open parenthesis newline is required
           if (queryArray[i] === '(') {
             unclosedParenthesisCount++;
 
             // If another open parenthesis is found before the closing parenthesis, add newline
-            if (query.substring(i+1).indexOf('(') < query.substring(i+1).indexOf(')') && query.substring(i+1).indexOf('(') !== -1) {
-              queryArray[i] = queryArray[i] + '<br>' + spaces(2*unclosedParenthesisCount + 6*gDotV.length);
-          
-            // Highlight parenthesis content orange if the next character is not the close parenthesis or the start of a string
-            } else if (!unclosedComment && ![')', "'", '{', '}'].includes(queryArray[i+1])) {
-              queryArray[i] = queryArray[i] + "<span style='color:Orange;'>"
+            if (
+              query.substring(i + 1).indexOf('(') <
+                query.substring(i + 1).indexOf(')') &&
+              query.substring(i + 1).indexOf('(') !== -1
+            ) {
+              queryArray[i] =
+                queryArray[i] +
+                '<br>' +
+                spaces(2 * unclosedParenthesisCount + 6 * gDotV.length);
+
+              // Highlight parenthesis content orange if the next character is not the close parenthesis or the start of a string
+            } else if (
+              !unclosedComment &&
+              ![')', "'", '{', '}'].includes(queryArray[i + 1])
+            ) {
+              queryArray[i] = queryArray[i] + "<span style='color:Orange;'>";
               unclosedValue = true;
             }
           } else if (queryArray[i] === ')') {
             unclosedParenthesisCount--;
-            unclosedParenthesisCount < gDotV[gDotV.length-1] && gDotV.length > 1 && (gDotV.length = gDotV.length-1);
-          
+            unclosedParenthesisCount < gDotV[gDotV.length - 1] &&
+              gDotV.length > 1 &&
+              (gDotV.length = gDotV.length - 1);
+
             // Close highlighting of parenthesis content
             if (!unclosedComment && unclosedValue) {
               queryArray[i] = '</span>' + queryArray[i];
@@ -297,21 +656,23 @@
     }
     let formattedQuery = queryArray.join('');
     return '<code>' + formattedQuery + '</code>';
-  }
+  };
 </script>
 
 <body>
   <center>
-    <div id='formatter' >
+    <div id="formatter">
       <form>
-        <textarea id='inputQuery'
-                  name='input'
-                  cols=80
-                  rows=12
-                  oninput="document.getElementById('inputQuery').rows = Math.max(value.split('\n').length, 12);
-                           document.getElementById('outputQuery').innerHTML=format(value);"></textarea>
+        <textarea
+          id="inputQuery"
+          name="input"
+          cols="80"
+          rows="12"
+          oninput="document.getElementById('inputQuery').rows = Math.max(value.split('\n').length, 12);
+                           document.getElementById('outputQuery').innerHTML=format(value);"
+        ></textarea>
       </form>
-      <div id='outputQuery'></div>
+      <div id="outputQuery"></div>
     </div>
   </center>
 </body>

--- a/run/index.js
+++ b/run/index.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { run } = require('./run');
 
 console.log(run(process.argv[2]));

--- a/run/run.js
+++ b/run/run.js
@@ -1,11 +1,27 @@
-const {
-  readContentFromFile,
-  writeContentToFile,
-} = require('../build/fileUtils');
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const { readContentFromFile } = require('../build/fileUtils');
 const { extractImportPaths } = require('../build/parseUtils');
 const { getOrderedListOfFiles } = require('../build/sortUtils');
 
-const run = pathOfFileToRun => {
+const run = (pathOfFileToRun) => {
   let importedFilePaths = {};
   let importQueue = [pathOfFileToRun];
 
@@ -22,7 +38,7 @@ const include = path => modules[path];
       content: fileContent,
       dependencies: paths,
     };
-    paths.forEach(path => {
+    paths.forEach((path) => {
       if (!importedFilePaths[path]) {
         importQueue.push(path);
       }

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const Navigator = include('src/components/navigator/Navigator.js');
 const StyleGuide = include('src/views/styleGuide/StyleGuide.js');
 const QueryFormatter = include('src/views/queryFormatter/QueryFormatter.js');

--- a/src/components/code/Code.js
+++ b/src/components/code/Code.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { html, If } = include('src/libs/simpleHTML/SimpleHTML.js');
 const { DisabledTextColor, TextColor } = include(
   'src/libs/simpleColorPalette/SimpleColorPalette.js'

--- a/src/components/fadeIn/FadeIn.js
+++ b/src/components/fadeIn/FadeIn.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 
 const FadeIn = (getProps, children) => {

--- a/src/components/loadingAnimation/LoadingAnimation.js
+++ b/src/components/loadingAnimation/LoadingAnimation.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 const { White } = include('src/libs/simpleColorPalette/SimpleColorPalette.js');
 

--- a/src/components/navigationButton/NavigationButton.js
+++ b/src/components/navigationButton/NavigationButton.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 const { getInlineContainerStyle, getLinkStyle } = include(
   'src/libs/simpleStyle/SimpleStyle.js'

--- a/src/components/navigator/Navigator.js
+++ b/src/components/navigator/Navigator.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 const { White } = include('src/libs/simpleColorPalette/SimpleColorPalette.js');
 const NavigationButton = include(

--- a/src/components/paragraph/Paragraph.js
+++ b/src/components/paragraph/Paragraph.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 const { TextColor } = include(
   'src/libs/simpleColorPalette/SimpleColorPalette.js'

--- a/src/components/queryInput/QueryInput.js
+++ b/src/components/queryInput/QueryInput.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 const { InputTextColor } = include(
   'src/libs/simpleColorPalette/SimpleColorPalette.js'

--- a/src/components/spacer/Spacer.js
+++ b/src/components/spacer/Spacer.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 
 const Spacer = () => html('div', { style: 'height: 20px' }, []);

--- a/src/components/styleGuideRule/StyleGuideRule.js
+++ b/src/components/styleGuideRule/StyleGuideRule.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const Title = include('src/components/title/Title.js');
 const Paragraph = include('src/components/paragraph/Paragraph.js');
 const Code = include('src/components/code/Code.js');

--- a/src/components/textButton/TextButton.js
+++ b/src/components/textButton/TextButton.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 const { getTextButtonStyle } = include('src/libs/simpleStyle/SimpleStyle.js');
 

--- a/src/components/title/Title.js
+++ b/src/components/title/Title.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 const { TextColor } = include(
   'src/libs/simpleColorPalette/SimpleColorPalette.js'

--- a/src/components/toggle/Toggle.js
+++ b/src/components/toggle/Toggle.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 const {
   getToggleContainerStyle,

--- a/src/components/toggle/styles.js
+++ b/src/components/toggle/styles.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { BorderColor, HighlightedTextColor, TextColor, White } = include(
   'src/libs/simpleColorPalette/SimpleColorPalette.js'
 );

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const Observable = include('src/libs/observable/Observable.js');
 const App = include('src/app/App.js');
 const Store = include('src/store/Store.js');

--- a/src/libs/gremlint/Gremlint.js
+++ b/src/libs/gremlint/Gremlint.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { pipe } = include('src/libs/simpleFP/SimpleFP.js');
 const { parseToSyntaxTree } = include(
   'src/libs/gremlint/parseToSyntaxTree/ParseToSyntaxTree.js'

--- a/src/libs/gremlint/formatSyntaxTree/FormatSyntaxTree.js
+++ b/src/libs/gremlint/formatSyntaxTree/FormatSyntaxTree.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { formatTraversal } = include(
   'src/libs/gremlint/formatSyntaxTree/formatTraversal/FormatTraversal.js'
 );

--- a/src/libs/gremlint/formatSyntaxTree/formatMethod/FormatMethod.js
+++ b/src/libs/gremlint/formatSyntaxTree/formatMethod/FormatMethod.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { pipe } = include('src/libs/simpleFP/SimpleFP.js');
 const { recreateQueryOnelinerFromSyntaxTree } = include(
   'src/libs/gremlint/recreateQueryOnelinerFromSyntaxTree/RecreateQueryOnelinerFromSyntaxTree.js'

--- a/src/libs/gremlint/formatSyntaxTree/formatString/FormatString.js
+++ b/src/libs/gremlint/formatSyntaxTree/formatString/FormatString.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const formatString = (config) => (syntaxTree) => {
   return {
     type: 'string',

--- a/src/libs/gremlint/formatSyntaxTree/formatTraversal/FormatTraversal.js
+++ b/src/libs/gremlint/formatSyntaxTree/formatTraversal/FormatTraversal.js
@@ -1,11 +1,29 @@
-const { pipe } = include('src/libs/simpleFP/SimpleFP.js');
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { recreateQueryOnelinerFromSyntaxTree } = include(
   'src/libs/gremlint/recreateQueryOnelinerFromSyntaxTree/RecreateQueryOnelinerFromSyntaxTree.js'
 );
 const { getStepGroups } = include(
   'src/libs/gremlint/formatSyntaxTree/formatTraversal/getStepGroups/GetStepGroups.js'
 );
-const { withDotInfo, withZeroIndentation } = include(
+const { withZeroIndentation } = include(
   'src/libs/gremlint/formatSyntaxTree/utils.js'
 );
 

--- a/src/libs/gremlint/formatSyntaxTree/formatTraversal/getStepGroups/GetStepGroups.js
+++ b/src/libs/gremlint/formatSyntaxTree/formatTraversal/getStepGroups/GetStepGroups.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { pipe } = include('src/libs/simpleFP/SimpleFP.js');
 const { withZeroIndentation, withIncreasedIndentation, withDotInfo } = include(
   'src/libs/gremlint/formatSyntaxTree/utils.js'

--- a/src/libs/gremlint/formatSyntaxTree/formatTraversal/getStepGroups/utils.js
+++ b/src/libs/gremlint/formatSyntaxTree/formatTraversal/getStepGroups/utils.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const isTraversalSource = (step) => step.type === 'word' && step.word === 'g';
 
 const isModulator = (step) =>

--- a/src/libs/gremlint/formatSyntaxTree/formatWord/FormatWord.js
+++ b/src/libs/gremlint/formatSyntaxTree/formatWord/FormatWord.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const formatWord = (config) => (syntaxTree) => {
   return {
     type: 'word',

--- a/src/libs/gremlint/formatSyntaxTree/utils.js
+++ b/src/libs/gremlint/formatSyntaxTree/utils.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const withIndentation = (indentation) => (config) => ({
   ...config,
   indentation,

--- a/src/libs/gremlint/parseToSyntaxTree/ParseToSyntaxTree.js
+++ b/src/libs/gremlint/parseToSyntaxTree/ParseToSyntaxTree.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { last, pipe } = include('src/libs/simpleFP/SimpleFP.js');
 
 const tokenizeOnTopLevelPunctuation = (query) => {

--- a/src/libs/gremlint/recreateQueryOnelinerFromSyntaxTree/RecreateQueryOnelinerFromSyntaxTree.js
+++ b/src/libs/gremlint/recreateQueryOnelinerFromSyntaxTree/RecreateQueryOnelinerFromSyntaxTree.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { spaces } = include('src/libs/gremlint/utils.js');
 
 const recreateQueryOnelinerFromSyntaxTree = (indentation = 0) => (

--- a/src/libs/gremlint/recreateQueryStringFromFormattedSyntaxTree/RecreateQueryStringFromFormattedSyntaxTree.js
+++ b/src/libs/gremlint/recreateQueryStringFromFormattedSyntaxTree/RecreateQueryStringFromFormattedSyntaxTree.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { spaces } = include('src/libs/gremlint/utils.js');
 
 const recreateQueryStringFromFormattedSyntaxTree = (syntaxTree) => {

--- a/src/libs/gremlint/utils.js
+++ b/src/libs/gremlint/utils.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const spaces = (numberOfSpaces) => Array(numberOfSpaces + 1).join(' ');
 
 module.exports = {

--- a/src/libs/observable/Observable.js
+++ b/src/libs/observable/Observable.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 class Observable {
   constructor(value) {
     // Maybe this can cause an id collision of two observables created almost at the same time

--- a/src/libs/simpleColorPalette/SimpleColorPalette.js
+++ b/src/libs/simpleColorPalette/SimpleColorPalette.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const BorderColor = 'lightgray';
 const TextColor = 'slategray';
 const InputTextColor = 'darkslategray';

--- a/src/libs/simpleFP/SimpleFP.js
+++ b/src/libs/simpleFP/SimpleFP.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const last = (array) => array.slice(-1)[0];
 
 const pipe = (...fns) => (value) => fns.reduce((value, fn) => fn(value), value);

--- a/src/libs/simpleHTML/SimpleHTML.js
+++ b/src/libs/simpleHTML/SimpleHTML.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const flatten = (items) => {
   const flat = [];
 

--- a/src/libs/simpleRouter/SimpleRouter.js
+++ b/src/libs/simpleRouter/SimpleRouter.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 function SimpleRouter(routes) {
   /**
    * @param {string} routes

--- a/src/libs/simpleState/SimpleState.js
+++ b/src/libs/simpleState/SimpleState.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const simpleState = (initialState) => {
   const state = initialState;
   const stateChangeCallbacks = [];

--- a/src/libs/simpleStyle/SimpleStyle.js
+++ b/src/libs/simpleStyle/SimpleStyle.js
@@ -1,10 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const {
   TextColor,
   InputTextColor,
   HighlightedTextColor,
-  DisabledTextColor,
   HighlightColor,
-  White,
 } = include('src/libs/simpleColorPalette/SimpleColorPalette.js');
 
 // A unit is 20px

--- a/src/router/Router.js
+++ b/src/router/Router.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const SimpleRouter = include('src/libs/simpleRouter/SimpleRouter.js');
 
 const router = new SimpleRouter({

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const Observable = include('src/libs/observable/Observable.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/src/views/queryFormatter/QueryFormatter.js
+++ b/src/views/queryFormatter/QueryFormatter.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const QueryInput = include('src/components/queryInput/QueryInput.js');
 const Code = include('src/components/code/Code.js');
 const TextButton = include('src/components/textButton/TextButton.js');

--- a/src/views/queryFormatter/advancedOptions/AdvancedOptions.js
+++ b/src/views/queryFormatter/advancedOptions/AdvancedOptions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const Toggle = include('src/components/toggle/Toggle.js');
 const { html } = include('src/libs/simpleHTML/SimpleHTML.js');
 const {

--- a/src/views/styleGuide/StyleGuide.js
+++ b/src/views/styleGuide/StyleGuide.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const StyleGuideRule = include(
   'src/components/styleGuideRule/StyleGuideRule.js'
 );

--- a/src/views/styleGuide/rules/Rules.js
+++ b/src/views/styleGuide/rules/Rules.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const rules = [
   {
     title: 'Break long queries into multiple lines',

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { run } = require('../run/run.js');
 
 run('test/tests/Tests.js');

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,25 @@
-const green = text => `\x1b[32m${text}\x1b[0m`;
-const red = text => `\x1b[31m${text}\x1b[0m`;
-const yellow = text => `\x1b[33m${text}\x1b[0m`;
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const green = (text) => `\x1b[32m${text}\x1b[0m`;
+const red = (text) => `\x1b[31m${text}\x1b[0m`;
+const yellow = (text) => `\x1b[33m${text}\x1b[0m`;
 
 /**
  *

--- a/test/tests/Tests.js
+++ b/test/tests/Tests.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { runTests, test, assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 const MaxLineLengthAssertions = include(

--- a/test/tests/dotsAfterNewlinesAssertions/DotsAfterNewlinesAssertions.js
+++ b/test/tests/dotsAfterNewlinesAssertions/DotsAfterNewlinesAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/test/tests/maxLineLengthAssertions/MaxLineLengthAssertions.js
+++ b/test/tests/maxLineLengthAssertions/MaxLineLengthAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/test/tests/modulatorIndentationAssertions/ModulatorIndentationAssertions.js
+++ b/test/tests/modulatorIndentationAssertions/ModulatorIndentationAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const ByModulatorIndentationAssertions = include(
   'test/tests/modulatorIndentationAssertions/byModulatorIndentationAssertions/ByModulatorIndentationAssertions.js'
 );

--- a/test/tests/modulatorIndentationAssertions/asModulatorIndentationAssertions/AsModulatorIndentationAssertions.js
+++ b/test/tests/modulatorIndentationAssertions/asModulatorIndentationAssertions/AsModulatorIndentationAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/test/tests/modulatorIndentationAssertions/as_ModulatorIndentationAssertions/As_ModulatorIndentationAssertions.js
+++ b/test/tests/modulatorIndentationAssertions/as_ModulatorIndentationAssertions/As_ModulatorIndentationAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/test/tests/modulatorIndentationAssertions/byModulatorIndentationAssertions/ByModulatorIndentationAssertions.js
+++ b/test/tests/modulatorIndentationAssertions/byModulatorIndentationAssertions/ByModulatorIndentationAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/test/tests/modulatorIndentationAssertions/emitModulatorIndentationAssertions/EmitModulatorIndentationAssertions.js
+++ b/test/tests/modulatorIndentationAssertions/emitModulatorIndentationAssertions/EmitModulatorIndentationAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/test/tests/modulatorIndentationAssertions/fromModulatorIndentationAssertions/FromModulatorIndentationAssertions.js
+++ b/test/tests/modulatorIndentationAssertions/fromModulatorIndentationAssertions/FromModulatorIndentationAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/test/tests/modulatorIndentationAssertions/from_ModulatorIndentationAssertions/From_ModulatorIndentationAssertions.js
+++ b/test/tests/modulatorIndentationAssertions/from_ModulatorIndentationAssertions/From_ModulatorIndentationAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/test/tests/modulatorIndentationAssertions/optionModulatorIndentationAssertions/OptionModulatorIndentationAssertions.js
+++ b/test/tests/modulatorIndentationAssertions/optionModulatorIndentationAssertions/OptionModulatorIndentationAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/test/tests/modulatorIndentationAssertions/readModulatorIndentationAssertions/ReadModulatorIndentationAssertions.js
+++ b/test/tests/modulatorIndentationAssertions/readModulatorIndentationAssertions/ReadModulatorIndentationAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/test/tests/modulatorIndentationAssertions/timesModulatorIndentationAssertions/TimesModulatorIndentationAssertions.js
+++ b/test/tests/modulatorIndentationAssertions/timesModulatorIndentationAssertions/TimesModulatorIndentationAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/test/tests/modulatorIndentationAssertions/toModulatorIndentationAssertions/ToModulatorIndentationAssertions.js
+++ b/test/tests/modulatorIndentationAssertions/toModulatorIndentationAssertions/ToModulatorIndentationAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/test/tests/modulatorIndentationAssertions/untilModulatorIndentationAssertions/UntilModulatorIndentationAssertions.js
+++ b/test/tests/modulatorIndentationAssertions/untilModulatorIndentationAssertions/UntilModulatorIndentationAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/test/tests/modulatorIndentationAssertions/withModulatorIndentationAssertions/WithModulatorIndentationAssertions.js
+++ b/test/tests/modulatorIndentationAssertions/withModulatorIndentationAssertions/WithModulatorIndentationAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/test/tests/modulatorIndentationAssertions/with_ModulatorIndentationAssertions/With_ModulatorIndentationAssertions.js
+++ b/test/tests/modulatorIndentationAssertions/with_ModulatorIndentationAssertions/With_ModulatorIndentationAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/test/tests/modulatorIndentationAssertions/writeModulatorIndentationAssertions/WriteModulatorIndentationAssertions.js
+++ b/test/tests/modulatorIndentationAssertions/writeModulatorIndentationAssertions/WriteModulatorIndentationAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/test/tests/modulatorWrappingAssertions/ModulatorWrappingAssertions.js
+++ b/test/tests/modulatorWrappingAssertions/ModulatorWrappingAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const ByModulatorWrappingAssertions = include(
   'test/tests/modulatorWrappingAssertions/byModulatorWrappingAssertions/ByModulatorWrappingAssertions.js'
 );

--- a/test/tests/modulatorWrappingAssertions/asModulatorWrappingAssertions/AsModulatorWrappingAssertions.js
+++ b/test/tests/modulatorWrappingAssertions/asModulatorWrappingAssertions/AsModulatorWrappingAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/test/tests/modulatorWrappingAssertions/byModulatorWrappingAssertions/ByModulatorWrappingAssertions.js
+++ b/test/tests/modulatorWrappingAssertions/byModulatorWrappingAssertions/ByModulatorWrappingAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/test/tests/nonMethodIndentationAssertions/NonMethodIndentationAssertions.js
+++ b/test/tests/nonMethodIndentationAssertions/NonMethodIndentationAssertions.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { assertEquals } = include('test/test.js');
 const { formatQuery } = include('src/libs/gremlint/Gremlint.js');
 

--- a/watch/index.js
+++ b/watch/index.js
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 const { build } = require('../build/build');
 
 const rebuild = () => {


### PR DESCRIPTION
Fixes https://github.com/OyvindSabo/gremlint/issues/56

Adding [ASF licence headers](https://www.apache.org/legal/src-headers.html) to all source files is necessary to fulfill the following point of the [Gremlint IP Clearance](https://incubator.apache.org/ip-clearance/tinkerpop-gremlint.html):

**Copyright**
*"Check and make sure that the files that have been donated have been updated to reflect the new ASF copyright."*